### PR TITLE
Update the YugabyteDB version automatically

### DIFF
--- a/.ci/find_container_image_tag.py
+++ b/.ci/find_container_image_tag.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Python script to find container image tag from YugabyteDB release version"""
+from optparse import OptionParser
+from re import match
+from requests import request
+from sys import exit
+
+REGISTRY_TAGS_URL = "https://registry.hub.docker.com/v1/repositories/yugabytedb/yugabyte/tags"
+
+
+def main(release):
+    """Use YugabyteDB release version to find respective container image tag"""
+    if not match("[0-9]+.[0-9]+.[0-9]+.[0-9]+", release.version):
+        exit("Version validation failed: required format: *.*.*.*")
+
+    response = request(method='GET', url=REGISTRY_TAGS_URL)
+    if not response.ok:
+        exit("Got {} from {}.".format(response.status_code, REGISTRY_TAGS_URL))
+    json_response = response.json()
+
+    tags = dict()
+    for tag_obj in json_response:
+        tag = tag_obj['name']
+        if tag.startswith(release.version):
+            build_number = int(tag[tag.rindex("-b")+2:])
+            tags[build_number] = tag
+    if not tags:
+        exit("Given version did not match any of the tags")
+
+    latest_build = max(tags.keys())
+    latest_tag = tags[latest_build]
+    if not match("[0-9]+.[0-9]+.[0-9]+.[0-9]+-b[0-9]+", latest_tag):
+        exit("Image tag '{}' is invalid, must be \
+of the form N.N.N.N-bN".format(latest_tag))
+    print(latest_tag)
+
+
+if __name__ == "__main__":
+    usage = "usage: %prog [options] -r <release-version>"
+    parser = OptionParser(usage)
+    parser.add_option("-r", "--release", type="string", dest="version")
+
+    (ARGS, OPTIONS) = parser.parse_args()
+
+    for option in ARGS.__dict__:
+        if ARGS.__dict__[option] is None:
+            parser.error("failed to parse the arguments.")
+    main(ARGS)

--- a/.ci/update_version.sh
+++ b/.ci/update_version.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+set -o errexit -o pipefail
+
+# version_gt compares the given two versions.
+# It returns 0 exit code if the version1 is greater than version2.
+# https://web.archive.org/web/20191003081436/http://ask.xmodulo.com/compare-two-version-numbers.html
+function version_gt() {
+  test "$(echo -e "$1\n$2" | sort -V | head -n 1)" != "$1"
+}
+
+
+if [[ -z "$1" ]]; then
+  echo "This script needs at least one argument, release_version is missing." 1>&2
+  exit 1
+fi
+
+release_version="$1"
+controller_go_file="pkg/controller/ybcluster/ybcluster_controller.go"
+custom_resource_file="deploy/crds/yugabyte.com_v1alpha1_ybcluster_full_cr.yaml"
+
+current_version_tag="$(grep -E \
+                    '^[[:space:]]+imageTagDefault[[:space:]]+=[[:space:]]+".*"' \
+                    "${controller_go_file}" | cut -d '"' -f "2")"
+if ! version_gt "${release_version}" "${current_version_tag%-b*}" ; then
+  echo "Release version is either older or equal to the current version: '${release_version}' <= '${current_version_tag%-b*}'" 1>&2
+  exit 1
+fi
+
+# find container image tag respective to YugabyteDB release version
+container_image_tag="$(python3 ".ci/find_container_image_tag.py" "-r" "${release_version}")"
+echo "Latest container image tag for '${release_version}': '${container_image_tag}'"
+
+# update the tag in Go source file
+echo "Updating file '${controller_go_file}' with tag '${container_image_tag}'."
+# sed: select the address range i.e. the line containing
+# yugabyteDBImageName and then replace 'z.y.z.w-bn' string from that
+# line https://unix.stackexchange.com/a/315082
+sed -i -E "/^[[:space:]]+yugabyteDBImageName[[:space:]]+=.*$/ \
+  s/[0-9]+.[0-9]+.[0-9]+.[0-9]+-b[0-9]+/${container_image_tag}/g" \
+  "${controller_go_file}"
+sed -i -E "/^[[:space:]]+imageTagDefault[[:space:]]+=.*$/ \
+  s/[0-9]+.[0-9]+.[0-9]+.[0-9]+-b[0-9]+/${container_image_tag}/g" \
+  "${controller_go_file}"
+
+# update the tag in custom resource manifest file
+echo "Updating file '${custom_resource_file}' with tag '${container_image_tag}'."
+sed -i -E "/^[[:space:]]{4}tag: .*$/ \
+  s/[0-9]+.[0-9]+.[0-9]+.[0-9]+-b[0-9]+/${container_image_tag}/g" \
+  "${custom_resource_file}"

--- a/.github/workflows/update-version.yaml
+++ b/.github/workflows/update-version.yaml
@@ -1,0 +1,53 @@
+name: "Update YugabyteDB version"
+on:
+  repository_dispatch:
+    types:
+    - update-on-release
+jobs:
+  update-version:
+    if: github.event.client_payload.prerelease == 'false'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: "Configure git"
+      run: |
+        git config user.name 'YugaByte CI'
+        git config user.email 'yugabyte-ci@users.noreply.github.com'
+    - name: "Extract version number from tag"
+      id: extract-version
+      run: |
+        tag_name="${{ github.event.client_payload.tag }}"
+        echo "Extracting version number from the tag '${tag_name}'."
+        version_number="${tag_name/v/}"
+        # Keep dots and count the string length
+        dot_count="$(res="${version_number//[^.]/}"; echo "${#res}")"
+        if [[ "${dot_count}" -eq 2 ]]; then
+          version_number="${version_number}.0"
+        fi
+        if [[ "$(res="${version_number//[^.]/}"; echo "${#res}")" -ne 3 ]]; then
+          echo "The tag '${tag_name}' is invalid. Expected format: 'v1.2.3' or 'v1.2.3.5'." 1>&2
+          exit 1
+        fi
+        echo "Extracted the version number '${version_number}'."
+        echo "::set-output name=yb_version::${version_number}"
+    - name: "Print Python version and install dependencies"
+      run: |
+        python3 --version
+        pip3 install requests
+    - name: "Update the version"
+      id: update-version
+      run: |
+        .ci/update_version.sh '${{steps.extract-version.outputs.yb_version}}'
+    - name: "Push the changes"
+      run: |
+        git status
+        git diff
+        git add "pkg/controller/ybcluster/ybcluster_controller.go" \
+          "deploy/crds/yugabyte.com_v1alpha1_ybcluster_full_cr.yaml"
+        git commit -m "Update the version to ${{steps.extract-version.outputs.yb_version}}"
+        git push origin ${{ github.ref }}
+    - name: "Show git status in case of failure"
+      if: failure() && steps.update-version.outcome == 'failure'
+      run: |
+        git status
+        git diff

--- a/deploy/crds/yugabyte.com_v1alpha1_ybcluster_full_cr.yaml
+++ b/deploy/crds/yugabyte.com_v1alpha1_ybcluster_full_cr.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   image:
     repository: yugabytedb/yugabyte
-    tag: 2.1.2.0-b10
+    tag: 2.3.2.0-b37
     pullPolicy: IfNotPresent
   tls:
     enabled: true

--- a/pkg/controller/ybcluster/ybcluster_controller.go
+++ b/pkg/controller/ybcluster/ybcluster_controller.go
@@ -64,7 +64,7 @@ const (
 	envPodIPVal                 = "status.podIP"
 	envPodName                  = "POD_NAME"
 	envPodNameVal               = "metadata.name"
-	yugabyteDBImageName         = "yugabytedb/yugabyte:2.1.2.0-b10"
+	yugabyteDBImageName         = "yugabytedb/yugabyte:2.3.2.0-b37"
 	imageRepositoryDefault      = "yugabytedb/yugabyte"
 	imageTagDefault             = "2.3.2.0-b37"
 	imagePullPolicyDefault      = corev1.PullIfNotPresent


### PR DESCRIPTION
- Updates the ybcluster_controller.go and
  yugabyte.com_v1alpha1_ybcluster_full_cr.yaml file.
- Uses Docker registry's API to fetch the latest tag for released
  version.
- https://registry.hub.docker.com/v1/repositories/yugabytedb/yugabyte/tags

This PR depends on https://github.com/yugabyte/yugabyte-db/pull/6025
Ref: https://github.com/yugabyte/yugabyte-db/issues/5987

### Scenarios tested
- Tried executing the scripts locally.

