### PR TITLE
Create Events when scaling down YB-TServers

### DIFF
--- a/pkg/controller/ybcluster/scale_tservers.go
+++ b/pkg/controller/ybcluster/scale_tservers.go
@@ -44,6 +44,11 @@ const (
 	noScaleDownInProgressMsg     string                 = "no TServer(s) are scaling down"
 )
 
+const (
+	scalingDownTServersEventReason string = "ScalingDownTServers"
+	scaledDownTServersEventReason  string = "ScaledDownTServers"
+)
+
 // scaleTServers determines if TServers are going to be scaled up or
 // scaled down. If scale down operation is required, it blacklists
 // TServer pods. Retruns boolean indicating if StatefulSet should be


### PR DESCRIPTION
Creates two events, `ScalingDownTServers` and `ScaledDownTServers`. These events get displayed when `kubectl describe ybcluster` command is executed.

### Scenarios tested

-   Tried creating a new ybcluster.
-   Scaled down the TServers replica count from 4 to 3.
-   The events were visible in the Events section of `kubectl describe ybclusters -nyb-operator example-ybcluster`.
    
    ```console
    $ kubectl describe ybclusters.yugabyte.com -nyb-operator example-ybcluster
    Name:         example-ybcluster
    Namespace:    yb-operator
    Labels:       <none>
    Annotations:  API Version:  yugabyte.com/v1alpha1
    Kind:         YBCluster
    …
    Events:
      Type     Reason               Age                 From                  Message
      ----     ------               ----                ----                  -------
      Warning  ScalingDownTServers  14m (x14 over 14m)  ybcluster-controller  Scaling down TServers to 3: waiting for data move to complete
      Normal   ScaledDownTServers   13m                 ybcluster-controller  Scaled down TServers successfully      
    ```