### PR TITLE
Fix validation issues with the full_cr.yaml

### DIFF
--- a/deploy/crds/yugabyte.com_v1alpha1_ybcluster_full_cr.yaml
+++ b/deploy/crds/yugabyte.com_v1alpha1_ybcluster_full_cr.yaml
@@ -27,10 +27,10 @@ spec:
       storageClass: standard
     resources:
       requests:
-        cpu: 0.2
+        cpu: 200m
         memory: 256Mi
       limits:
-        cpu: 0.5
+        cpu: 500m
         memory: 512Mi
     gflags:
       - key: default_memory_limit_to_ram_ratio
@@ -53,10 +53,10 @@ spec:
       storageClass: standard
     resources:
       requests:
-        cpu: 0.2
+        cpu: 200m
         memory: 256Mi
       limits:
-        cpu: 0.5
+        cpu: 500m
         memory: 512Mi
     gflags:
       - key: default_memory_limit_to_ram_ratio


### PR DESCRIPTION
The OpenAPIV3 schema is used to validate the YAML manifest, according to it the cpu resource value must be a string or integer. For float values it can be something like "0.2" (a string). This gets converted to 200m internally. Setting the values to the internal representation to avoid any confusion.

<https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu>

### Scenarios tested

-   Applied the modified full_cr.yaml file, there were no validation errors and cluster was setup with correct values.

Fixes https://github.com/yugabyte/yugabyte-db/issues/6349