### PR TITLE
Fix tserverUIPort constraint in CRD to allow deleting TserverUI service

### DIFF
--- a/deploy/crds/yugabyte.com_ybclusters_crd.yaml
+++ b/deploy/crds/yugabyte.com_ybclusters_crd.yaml
@@ -211,7 +211,6 @@ spec:
                   type: integer
                 tserverUIPort:
                   format: int32
-                  minimum: 1
                   type: integer
                 ycqlPort:
                   format: int32


### PR DESCRIPTION
Remove the `min: 1` constraint on spec.tserver.tserverUIPort in CRD(yugabyte.com_ybclusters_crd.yaml) to allow users to delete TserverUI service.

Solves #33 