### PR TITLE
Update `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1` for the CRD

### DIFF
--- a/deploy/crds/yugabyte.com_ybclusters_crd.yaml
+++ b/deploy/crds/yugabyte.com_ybclusters_crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: ybclusters.yugabyte.com
@@ -10,295 +10,294 @@ spec:
     plural: ybclusters
     singular: ybcluster
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      description: YBCluster is the Schema for the ybclusters API
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: YBClusterSpec defines the desired state of YBCluster
-          properties:
-            domain:
-              description: Domain name for Kubernetes cluster
-              type: string
-            image:
-              description: YBImageSpec defines docker image specific attributes.
-              properties:
-                pullPolicy:
-                  description: PullPolicy describes a policy for if/when to pull a
-                    container image
-                  type: string
-                repository:
-                  type: string
-                tag:
-                  type: string
-              type: object
-            master:
-              description: YBMasterSpec defines attributes for YBMaster pods.
-              properties:
-                enableLoadBalancer:
-                  type: boolean
-                gflags:
-                  items:
-                    description: YBGFlagSpec defines key-value pairs for each GFlag.
-                    properties:
-                      key:
-                        type: string
-                      value:
-                        type: string
-                    type: object
-                  minItems: 1
-                  type: array
-                masterRPCPort:
-                  format: int32
-                  minimum: 1
-                  type: integer
-                masterUIPort:
-                  format: int32
-                  minimum: 1
-                  type: integer
-                podManagementPolicy:
-                  description: PodManagementPolicyType defines the policy for creating
-                    pods under a stateful set.
-                  type: string
-                replicas:
-                  format: int32
-                  minimum: 1
-                  type: integer
-                resources:
-                  description: ResourceRequirements describes the compute resource
-                    requirements.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                storage:
-                  description: YBStorageSpec defines storage specific attributes for
-                    YBMaster/YBTserver pods.
-                  properties:
-                    count:
-                      format: int32
-                      minimum: 1
-                      type: integer
-                    size:
-                      pattern: ^[0-9]{1,4}[MGT][IBib]$
-                      type: string
-                    storageClass:
-                      type: string
-                  type: object
-              type: object
-            replicationFactor:
-              description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
-                Important: Run "operator-sdk generate k8s" to regenerate code after
-                modifying this file Add custom validation using kubebuilder tags:
-                https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              format: int32
-              minimum: 1
-              type: integer
-            tls:
-              description: YBTLSSpec defines TLS encryption specific attributes
-              properties:
-                enabled:
-                  type: boolean
-                rootCA:
-                  description: YBRootCASpec defines Root CA cert & key attributes
-                    required for enabling TLS encryption.
-                  properties:
-                    cert:
-                      type: string
-                    key:
-                      type: string
-                  type: object
-              type: object
-            tserver:
-              description: YBTServerSpec defines attributes for YBTServer pods.
-              properties:
-                enableLoadBalancer:
-                  type: boolean
-                gflags:
-                  items:
-                    description: YBGFlagSpec defines key-value pairs for each GFlag.
-                    properties:
-                      key:
-                        type: string
-                      value:
-                        type: string
-                    type: object
-                  minItems: 1
-                  type: array
-                podManagementPolicy:
-                  description: PodManagementPolicyType defines the policy for creating
-                    pods under a stateful set.
-                  type: string
-                replicas:
-                  format: int32
-                  minimum: 1
-                  type: integer
-                resources:
-                  description: ResourceRequirements describes the compute resource
-                    requirements.
-                  properties:
-                    limits:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Limits describes the maximum amount of compute
-                        resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                    requests:
-                      additionalProperties:
-                        anyOf:
-                        - type: integer
-                        - type: string
-                        pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                        x-kubernetes-int-or-string: true
-                      description: 'Requests describes the minimum amount of compute
-                        resources required. If Requests is omitted for a container,
-                        it defaults to Limits if that is explicitly specified, otherwise
-                        to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
-                      type: object
-                  type: object
-                storage:
-                  description: YBStorageSpec defines storage specific attributes for
-                    YBMaster/YBTserver pods.
-                  properties:
-                    count:
-                      format: int32
-                      minimum: 1
-                      type: integer
-                    size:
-                      pattern: ^[0-9]{1,4}[MGT][IBib]$
-                      type: string
-                    storageClass:
-                      type: string
-                  type: object
-                tserverRPCPort:
-                  format: int32
-                  minimum: 1
-                  type: integer
-                tserverUIPort:
-                  format: int32
-                  minimum: 1
-                  type: integer
-                ycqlPort:
-                  format: int32
-                  minimum: 1
-                  type: integer
-                yedisPort:
-                  format: int32
-                  minimum: 1
-                  type: integer
-                ysqlPort:
-                  format: int32
-                  minimum: 1
-                  type: integer
-              type: object
-          type: object
-        status:
-          description: YBClusterStatus defines the observed state of YBCluster
-          properties:
-            conditions:
-              description: Conditions represent the latest available observations
-                of an object's state
-              items:
-                description: "Condition represents an observation of an object's state.
-                  Conditions are an extension mechanism intended to be used when the
-                  details of an observation are not a priori known or would not apply
-                  to all instances of a given Kind. \n Conditions should be added
-                  to explicitly convey properties that users and components care about
-                  rather than requiring those properties to be inferred from other
-                  observations. Once defined, the meaning of a Condition can not be
-                  changed arbitrarily - it becomes part of the API, and has the same
-                  backwards- and forwards-compatibility concerns of any other part
-                  of the API."
-                properties:
-                  lastTransitionTime:
-                    format: date-time
-                    type: string
-                  message:
-                    type: string
-                  reason:
-                    description: ConditionReason is intended to be a one-word, CamelCase
-                      representation of the category of cause of the current status.
-                      It is intended to be used in concise output, such as one-line
-                      kubectl get output, and in summarizing occurrences of causes.
-                    type: string
-                  status:
-                    type: string
-                  type:
-                    description: "ConditionType is the type of the condition and is
-                      typically a CamelCased word or short phrase. \n Condition types
-                      should indicate state in the \"abnormal-true\" polarity. For
-                      example, if the condition indicates when a policy is invalid,
-                      the \"is valid\" case is probably the norm, so the condition
-                      should be called \"Invalid\"."
-                    type: string
-                required:
-                - status
-                - type
-                type: object
-              type: array
-            masterReplicas:
-              description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
-                of cluster Important: Run "operator-sdk generate k8s" to regenerate
-                code after modifying this file Add custom validation using kubebuilder
-                tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
-              format: int64
-              type: integer
-            targetedTServerReplicas:
-              description: TargetedTServerReplicas is the desired number of replicas
-                currently targeted. If any other operation is going on, then change
-                in spec.tserver.replicas won't modify this value until the operation
-                is completed.
-              format: int32
-              type: integer
-            tserverReplicas:
-              format: int64
-              type: integer
-          required:
-          - masterReplicas
-          - targetedTServerReplicas
-          - tserverReplicas
-          type: object
-      type: object
-  version: v1alpha1
   versions:
   - name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: YBCluster is the Schema for the ybclusters API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: YBClusterSpec defines the desired state of YBCluster
+            properties:
+              domain:
+                description: Domain name for Kubernetes cluster
+                type: string
+              image:
+                description: YBImageSpec defines docker image specific attributes.
+                properties:
+                  pullPolicy:
+                    description: PullPolicy describes a policy for if/when to pull a
+                      container image
+                    type: string
+                  repository:
+                    type: string
+                  tag:
+                    type: string
+                type: object
+              master:
+                description: YBMasterSpec defines attributes for YBMaster pods.
+                properties:
+                  enableLoadBalancer:
+                    type: boolean
+                  gflags:
+                    items:
+                      description: YBGFlagSpec defines key-value pairs for each GFlag.
+                      properties:
+                        key:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    minItems: 1
+                    type: array
+                  masterRPCPort:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  masterUIPort:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  podManagementPolicy:
+                    description: PodManagementPolicyType defines the policy for creating
+                      pods under a stateful set.
+                    type: string
+                  replicas:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  storage:
+                    description: YBStorageSpec defines storage specific attributes for
+                      YBMaster/YBTserver pods.
+                    properties:
+                      count:
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      size:
+                        pattern: ^[0-9]{1,4}[MGT][IBib]$
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                type: object
+              replicationFactor:
+                description: 'INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+                  Important: Run "operator-sdk generate k8s" to regenerate code after
+                  modifying this file Add custom validation using kubebuilder tags:
+                  https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                format: int32
+                minimum: 1
+                type: integer
+              tls:
+                description: YBTLSSpec defines TLS encryption specific attributes
+                properties:
+                  enabled:
+                    type: boolean
+                  rootCA:
+                    description: YBRootCASpec defines Root CA cert & key attributes
+                      required for enabling TLS encryption.
+                    properties:
+                      cert:
+                        type: string
+                      key:
+                        type: string
+                    type: object
+                type: object
+              tserver:
+                description: YBTServerSpec defines attributes for YBTServer pods.
+                properties:
+                  enableLoadBalancer:
+                    type: boolean
+                  gflags:
+                    items:
+                      description: YBGFlagSpec defines key-value pairs for each GFlag.
+                      properties:
+                        key:
+                          type: string
+                        value:
+                          type: string
+                      type: object
+                    minItems: 1
+                    type: array
+                  podManagementPolicy:
+                    description: PodManagementPolicyType defines the policy for creating
+                      pods under a stateful set.
+                    type: string
+                  replicas:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  resources:
+                    description: ResourceRequirements describes the compute resource
+                      requirements.
+                    properties:
+                      limits:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Limits describes the maximum amount of compute
+                          resources allowed. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                      requests:
+                        additionalProperties:
+                          anyOf:
+                          - type: integer
+                          - type: string
+                          pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                          x-kubernetes-int-or-string: true
+                        description: 'Requests describes the minimum amount of compute
+                          resources required. If Requests is omitted for a container,
+                          it defaults to Limits if that is explicitly specified, otherwise
+                          to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/'
+                        type: object
+                    type: object
+                  storage:
+                    description: YBStorageSpec defines storage specific attributes for
+                      YBMaster/YBTserver pods.
+                    properties:
+                      count:
+                        format: int32
+                        minimum: 1
+                        type: integer
+                      size:
+                        pattern: ^[0-9]{1,4}[MGT][IBib]$
+                        type: string
+                      storageClass:
+                        type: string
+                    type: object
+                  tserverRPCPort:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  tserverUIPort:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  ycqlPort:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  yedisPort:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                  ysqlPort:
+                    format: int32
+                    minimum: 1
+                    type: integer
+                type: object
+            type: object
+          status:
+            description: YBClusterStatus defines the observed state of YBCluster
+            properties:
+              conditions:
+                description: Conditions represent the latest available observations
+                  of an object's state
+                items:
+                  description: "Condition represents an observation of an object's state.
+                    Conditions are an extension mechanism intended to be used when the
+                    details of an observation are not a priori known or would not apply
+                    to all instances of a given Kind. \n Conditions should be added
+                    to explicitly convey properties that users and components care about
+                    rather than requiring those properties to be inferred from other
+                    observations. Once defined, the meaning of a Condition can not be
+                    changed arbitrarily - it becomes part of the API, and has the same
+                    backwards- and forwards-compatibility concerns of any other part
+                    of the API."
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      description: ConditionReason is intended to be a one-word, CamelCase
+                        representation of the category of cause of the current status.
+                        It is intended to be used in concise output, such as one-line
+                        kubectl get output, and in summarizing occurrences of causes.
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      description: "ConditionType is the type of the condition and is
+                        typically a CamelCased word or short phrase. \n Condition types
+                        should indicate state in the \"abnormal-true\" polarity. For
+                        example, if the condition indicates when a policy is invalid,
+                        the \"is valid\" case is probably the norm, so the condition
+                        should be called \"Invalid\"."
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              masterReplicas:
+                description: 'INSERT ADDITIONAL STATUS FIELD - define observed state
+                  of cluster Important: Run "operator-sdk generate k8s" to regenerate
+                  code after modifying this file Add custom validation using kubebuilder
+                  tags: https://book-v1.book.kubebuilder.io/beyond_basics/generating_crd.html'
+                format: int64
+                type: integer
+              targetedTServerReplicas:
+                description: TargetedTServerReplicas is the desired number of replicas
+                  currently targeted. If any other operation is going on, then change
+                  in spec.tserver.replicas won't modify this value until the operation
+                  is completed.
+                format: int32
+                type: integer
+              tserverReplicas:
+                format: int64
+                type: integer
+            required:
+            - masterReplicas
+            - targetedTServerReplicas
+            - tserverReplicas
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}


### PR DESCRIPTION
Modify the CRD accordingly:

Moved the `openAPIV3Schema` to `versions` and removed deprecated fields.

Fix for https://github.com/yugabyte/yugabyte-operator/issues/24